### PR TITLE
Index imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "john-wick-parse"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "bitreader 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "john-wick-parse"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Waddlesworth <github@genj.io>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 byteorder = "1.2"
 hex = "0.3"
-serde = "1.0"
+serde = { version = "1.0", features = ["rc"] }
 serde_json = "1.0"
 serde_derive = "1.0"
 erased-serde = "0.3"

--- a/src/anims.rs
+++ b/src/anims.rs
@@ -188,6 +188,10 @@ fn get_skeleton_map(anim: &UAnimSequence) -> ParserResult<Vec<String>> {
         FPropertyTagType::ObjectProperty(import) => import.get_import(),
         _ => return Err(ParserError::new(format!("Skeleton unreadable format"))),
     };
+    let path = match path {
+        Some(data) => data.get_name(),
+        None => return Err(ParserError::new(format!("Import not valid"))),
+    };
 
     let skeleton_path = "skeletons/".to_owned() + path;
     let package = Package::from_file(&skeleton_path)?;

--- a/src/archives.rs
+++ b/src/archives.rs
@@ -196,11 +196,11 @@ impl PakExtractor {
         let mut header_b = vec![0u8; PAK_SIZE as usize];
         reader.read_exact(&mut header_b)?;
 
-        let mut header_reader = Cursor::new(header_b);
+        let mut header_reader = Cursor::new(header_b.as_slice());
         let header = FPakInfo::new(&mut header_reader)?;
 
         let index_data = get_index(&header, &mut reader, key);
-        let mut index_reader = Cursor::new(index_data);
+        let mut index_reader = Cursor::new(index_data.as_slice());
         let index = FPakIndex::new(&mut index_reader)?;
 
         Ok(Self {
@@ -218,7 +218,7 @@ impl PakExtractor {
         let mut header_b = vec![0u8; PAK_SIZE as usize];
         reader.read_exact(&mut header_b)?;
 
-        let mut header_reader = Cursor::new(header_b);
+        let mut header_reader = Cursor::new(header_b.as_slice());
         let header = FPakInfo::new(&mut header_reader)?;
 
         Ok(header)

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -19,7 +19,7 @@ pub use anims::{USkeleton, UAnimSequence, FTrack};
 pub use meshes::{USkeletalMesh, FMultisizeIndexContainer, FStaticMeshVertexDataTangent, FSkeletalMeshRenderData,
     FSkelMeshRenderSection, FSkeletalMaterial, FSkinWeightVertexBuffer, FMeshBoneInfo, FStaticMeshVertexDataUV, FReferenceSkeleton};
 
-pub type ReaderCursor = Cursor<Vec<u8>>;
+pub type ReaderCursor<'c> = Cursor<&'c[u8]>;
 
 /// ParserError contains a list of error messages that wind down to where the parser was not able to parse a property
 #[derive(Debug)]
@@ -2346,7 +2346,7 @@ pub struct Package {
 
 #[allow(dead_code)]
 impl Package {
-    pub fn from_buffer(uasset: Vec<u8>, uexp: Vec<u8>, ubulk: Option<Vec<u8>>) -> ParserResult<Self> {
+    pub fn from_buffer(uasset: &[u8], uexp: &[u8], ubulk: Option<&[u8]>) -> ParserResult<Self> {
         let mut cursor = ReaderCursor::new(uasset);
         let summary = FPackageFileSummary::new(&mut cursor)?;
 
@@ -2445,7 +2445,11 @@ impl Package {
             false => None,
         };
 
-        Self::from_buffer(uasset_buf, uexp_buf, ubulk_buf)
+        // ??
+        match ubulk_buf {
+            Some(data) => Self::from_buffer(&uasset_buf, &uexp_buf, Some(&data)),
+            None => Self::from_buffer(&uasset_buf, &uexp_buf, None),
+        }
     }
 
     pub fn get_exports(self) -> Vec<Box<dyn Any>> {

--- a/src/assets/anims.rs
+++ b/src/assets/anims.rs
@@ -316,7 +316,7 @@ impl UAnimSequence {
         if self.key_encoding_format != 2 {
             return Err(ParserError::new(format!("Can only parse PerTrackCompression")));
         }
-        let mut reader = ReaderCursor::new(self.compressed_stream.clone());
+        let mut reader = ReaderCursor::new(&self.compressed_stream);
         let num_tracks = self.compressed_track_offsets.len() / 2;
         // TODO: Use UObject property instead.
         let num_frames = self.compressed_num_frames;

--- a/src/assets/locale.rs
+++ b/src/assets/locale.rs
@@ -54,7 +54,7 @@ pub struct FTextLocalizationResource {
 }
 
 impl FTextLocalizationResource {
-    pub fn from_buffer(locres: Vec<u8>) -> ParserResult<Self> {
+    pub fn from_buffer(locres: &[u8]) -> ParserResult<Self> {
         let mut reader = ReaderCursor::new(locres);
         let magic = FGuid::new(&mut reader)?;
 

--- a/src/assets/meshes.rs
+++ b/src/assets/meshes.rs
@@ -331,7 +331,10 @@ pub struct FSkeletalMaterial {
 
 impl FSkeletalMaterial {
     pub fn get_interface(&self) -> &str {
-        &self.material_interface.import
+        match &self.material_interface.import {
+            Some(data) => &data.object_name,
+            None => panic!("No import exists"),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod texture;
 mod rijndael;
 
 /// Reads an uasset and uexp file into a Package with all of its exports
-pub fn read_asset(asset: Vec<u8>, uexp: Vec<u8>, ubulk: Option<Vec<u8>>) -> ParserResult<Package> {
+pub fn read_asset(asset: &[u8], uexp: &[u8], ubulk: Option<&[u8]>) -> ParserResult<Package> {
     Package::from_buffer(asset, uexp, ubulk)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,7 @@ fn locale(params: &[String]) -> CommandResult {
     let mut locres_buf = Vec::new();
     locres.read_to_end(&mut locres_buf).unwrap();
 
-    let package = assets::locale::FTextLocalizationResource::from_buffer(locres_buf)?;
+    let package = assets::locale::FTextLocalizationResource::from_buffer(&locres_buf)?;
     let serial_package = serde_json::to_string(&package).unwrap();
     let mut file = fs::File::create(path.to_owned() + ".json").unwrap();
     file.write_all(serial_package.as_bytes()).unwrap();

--- a/src/meshes.rs
+++ b/src/meshes.rs
@@ -398,7 +398,10 @@ fn load_material(mesh_data: &mut GLTFItem, material_name: &str) -> ParserResult<
         let texture_name = val_struct.iter().fold(None, |acc, x| {
             if x.get_name() == "ParameterValue" {
                 return match x.get_data() {
-                    FPropertyTagType::ObjectProperty(index) => Some(index.get_import()),
+                    FPropertyTagType::ObjectProperty(index) => Some(match index.get_import() {
+                        Some(data) => data.get_name(),
+                        None => panic!("Import does not exist"),
+                    }),
                     _ => panic!("Not an FPackageIndex"),
                 };
             }


### PR DESCRIPTION
This is a version bump to v4, as the import functionality changes significantly. For an FPackageIndex structure, instead of serializing the closest object_name, it will serialize the entire tree and format it as an array of strings.

When the FPackageIndex points to an export, it presents as an object instead of an array, with a single key `export` along with the index.

Another improvement is that this is now using slices instead of Vec for the reader, since they're read-only anyway. This means that fewer memory copies should be necessary for library use (although in the case of a CLI and native libraries, a move is used, so there is no speedup there)
